### PR TITLE
Interpret compiler exit codes

### DIFF
--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/ExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/ExeRunner.java
@@ -13,6 +13,12 @@ import java.util.concurrent.CompletableFuture;
 public class ExeRunner {
 
     public CompletableFuture<OrError<String>> run(Path exe, List<String> args, InputStream stdin) {
-        return Subprocess.run(exe, args, stdin);
+        return Subprocess.run(exe, args, stdin).thenApply(output -> {
+            if (output.isExitSuccess()) {
+                return OrError.ok(output.getStdout());
+            } else {
+                return OrError.error(output.getStderr());
+            }
+        });
     }
 }


### PR DESCRIPTION
Errors with the compiler invocation / setup are now 500s rather than returned as user code errors `{ error : ... }`

Closes #5 