### PR TITLE
Fix override of compiler image to apply to runner also

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -14,6 +14,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: koka-playground-runner-service
+      args:
+        RUN_COMPILER_IMAGE: run-koka-compiler:latest
 
     security_opt:
       - seccomp:seccomp/bwrap-seccomp-profile.json


### PR DESCRIPTION
Failing to override means getting libraries from the amd64 prod image, but compiling for aarch64.