### PR TITLE
Truncate error messages before sending over websocket

### DIFF
--- a/app/runner-service-app/src/main/resources/application.properties
+++ b/app/runner-service-app/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.application.name=koka-playground
 which-exe-store=local-exe-store
 server.port=80
 runner.max-buffered-stdin-items=1000
+runner.max-stderr-bytes=1000

--- a/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunTest.java
+++ b/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunTest.java
@@ -38,7 +38,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = {TestConfig.class, CompileService.class, RunnerService.class})
 @TestPropertySource(properties = {
         "runner-service-hostname=UNUSED",
-        "runner.max-buffered-stdin-items=10"})
+        "runner.max-buffered-stdin-items=10",
+        "runner.max-stderr-bytes=100"})
 public class CompileAndRunTest {
     // mocked services:
     @MockitoBean

--- a/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunWebSocketTest.java
+++ b/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunWebSocketTest.java
@@ -45,7 +45,8 @@ import static org.junit.Assert.assertThrows;
         "compiler.koka-zero-config-path=UNUSED",
         "runner.bubblewrap-path=UNUSED",
         "runner-service-hostname=UNUSED",
-        "runner.max-buffered-stdin-items=10"})
+        "runner.max-buffered-stdin-items=10",
+        "runner.max-stderr-bytes=100"})
 public class CompileAndRunWebSocketTest {
 
     // mocked services

--- a/integration/src/test/java/uk/danielgooding/kokaplayground/RunWebSocketTest.java
+++ b/integration/src/test/java/uk/danielgooding/kokaplayground/RunWebSocketTest.java
@@ -38,7 +38,8 @@ import static org.junit.Assert.assertThrows;
         "compiler.koka-zero-config-path=UNUSED",
         "runner.bubblewrap-path=UNUSED",
         "runner-service-hostname=UNUSED",
-        "runner.max-buffered-stdin-items=10"})
+        "runner.max-buffered-stdin-items=10",
+        "runner.max-stderr-bytes=100"})
 public class RunWebSocketTest {
 
     // mocked services


### PR DESCRIPTION
Truncate process stderr before sending as Error message over websocket. Multi-part messages aren't trivial to implement (we have to detect invalid json and wait), so truncation is fine for now.