### PR TITLE
Enable input element only once runs starts

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -54,6 +54,9 @@ function runCode() {
         } else if (message.hasOwnProperty("starting-compilation")) {
             setState({runStatus: "compiling"})
 
+        } else if (message.hasOwnProperty("starting-run")) {
+            setState({runStatus: "startingRun"})
+
         } else if (message.hasOwnProperty("running")) {
             setState({runStatus: "running"})
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -32,9 +32,7 @@ function runCode() {
 
         websocket.send(JSON.stringify({
             "@type": "compile-and-run",
-            sourceCode: {
-                code: editor.value
-            }
+            code: editor.value
         }))
 
         setState({runStatus: "requestedRun"})

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -1,4 +1,4 @@
-export type RunStatus = "idle" | "connecting" | "requestedRun" | "compiling" | "running"
+export type RunStatus = "idle" | "connecting" | "requestedRun" | "compiling" | "startingRun" | "running"
 
 export type State = {
     runStatus: RunStatus,

--- a/client/src/view.ts
+++ b/client/src/view.ts
@@ -24,33 +24,32 @@ export const editor = basicEditor(
         value: fibonacciGeneratorCode
     })
 
-function updateViewForRunStatus(state: State) {
-    let content: string;
+function statusDescription(state: State): string {
     switch (state.runStatus) {
         case "idle":
             if (state.error != null) {
-                content = "failed"
+                return "failed"
             } else {
-                content = ""
+                return ""
             }
-            break;
         case "connecting":
-            content = "connecting..."
-            break
+            return "connecting..."
         case "requestedRun":
-            content = "awaiting run..."
-            break
+            return "awaiting run..."
         case "compiling":
-            content = "compiling..."
-            break
+            return "compiling..."
+        case "startingRun":
+            return "starting..."
         case "running":
-            content = "running..."
-            break
+            return "running..."
     }
-    runStatusDiv.textContent = content
+}
+
+function updateViewForRunStatus(state: State) {
+    runStatusDiv.textContent = statusDescription(state);
 
     runButton.disabled = state.runStatus !== "idle"
-    stdinInput.disabled = state.runStatus === "idle"
+    stdinInput.disabled = state.runStatus !== "running"
 
     // Hide placeholder when disabled
     if (stdinInput.disabled) {

--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/KokaSourceCode.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/KokaSourceCode.java
@@ -2,13 +2,13 @@ package uk.danielgooding.kokaplayground.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import java.util.Objects;
 
 public class KokaSourceCode {
     private final String code;
 
-    @JsonCreator
     public KokaSourceCode(@JsonProperty("code") String code) {
         this.code = code;
     }

--- a/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
+++ b/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
@@ -23,10 +23,11 @@ public class CompileAndRunStream {
 
         @JsonTypeName("compile-and-run")
         public static final class CompileAndRun extends Message {
+            @JsonUnwrapped
             private final KokaSourceCode sourceCode;
 
             @JsonCreator
-            public CompileAndRun(@JsonProperty("sourceCode") KokaSourceCode sourceCode) {
+            public CompileAndRun(KokaSourceCode sourceCode) {
                 this.sourceCode = sourceCode;
             }
 

--- a/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
+++ b/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
@@ -106,6 +106,18 @@ public class CompileAndRunStream {
             }
         }
 
+        @JsonTypeName("starting-run")
+        public static final class StartingRun extends Message {
+            @JsonCreator
+            public StartingRun() {
+            }
+
+            @Override
+            public String toString() {
+                return "StartingRun";
+            }
+        }
+
         @JsonTypeName("running")
         public static final class Running extends Message {
             @JsonCreator
@@ -114,7 +126,7 @@ public class CompileAndRunStream {
 
             @Override
             public String toString() {
-                return "StartingCompilation";
+                return "Running";
             }
         }
 

--- a/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
+++ b/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
@@ -11,7 +11,7 @@ import uk.danielgooding.kokaplayground.common.exe.ExeHandle;
 public class CompileAndRunStream {
 
     public static class Inbound {
-        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
         @JsonSubTypes({
                 @JsonSubTypes.Type(value = CompileAndRun.class, name = "compile-and-run"),
                 @JsonSubTypes.Type(value = Stdin.class, name = "stdin")
@@ -67,7 +67,7 @@ public class CompileAndRunStream {
     }
 
     public static class Outbound {
-        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
         @JsonSubTypes({
                 @JsonSubTypes.Type(value = AnotherRequestInProgress.class, name = "another-request-in-progress"),
                 @JsonSubTypes.Type(value = StartingCompilation.class, name = "starting-compilation"),

--- a/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/RunStream.java
+++ b/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/RunStream.java
@@ -21,10 +21,11 @@ public class RunStream {
 
         @JsonTypeName("run")
         public static final class Run extends Message {
+            @JsonUnwrapped
             private final ExeHandle exeHandle;
 
             @JsonCreator
-            public Run(@JsonProperty("exeHandle") ExeHandle handle) {
+            public Run(ExeHandle handle) {
                 this.exeHandle = handle;
             }
 

--- a/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/RunStream.java
+++ b/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/RunStream.java
@@ -65,7 +65,7 @@ public class RunStream {
     }
 
     public static class Outbound {
-        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
         @JsonSubTypes({
                 @JsonSubTypes.Type(value = AnotherRequestInProgress.class, name = "another-request-in-progress"),
                 @JsonSubTypes.Type(value = Starting.class, name = "starting"),


### PR DESCRIPTION
Fix an early send of the Running message, and make the input box disabled until the run has actually started.