### PR TITLE
Restructure JSON messages to be nicer to use in JS

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -54,6 +54,9 @@ function runCode() {
         } else if (message.hasOwnProperty("starting-compilation")) {
             setState({runStatus: "compiling"})
 
+        } else if (message.hasOwnProperty("starting-run")) {
+            setState({runStatus: "startingRun"})
+
         } else if (message.hasOwnProperty("running")) {
             setState({runStatus: "running"})
 

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -1,4 +1,4 @@
-export type RunStatus = "idle" | "connecting" | "requestedRun" | "compiling" | "running"
+export type RunStatus = "idle" | "connecting" | "requestedRun" | "compiling" | "startingRun" | "running"
 
 export type State = {
     runStatus: RunStatus,

--- a/client/src/view.ts
+++ b/client/src/view.ts
@@ -24,33 +24,32 @@ export const editor = basicEditor(
         value: fibonacciGeneratorCode
     })
 
-function updateViewForRunStatus(state: State) {
-    let content: string;
+function statusDescription(state: State): string {
     switch (state.runStatus) {
         case "idle":
             if (state.error != null) {
-                content = "failed"
+                return "failed"
             } else {
-                content = ""
+                return ""
             }
-            break;
         case "connecting":
-            content = "connecting..."
-            break
+            return "connecting..."
         case "requestedRun":
-            content = "awaiting run..."
-            break
+            return "awaiting run..."
         case "compiling":
-            content = "compiling..."
-            break
+            return "compiling..."
+        case "startingRun":
+            return "starting..."
         case "running":
-            content = "running..."
-            break
+            return "running..."
     }
-    runStatusDiv.textContent = content
+}
+
+function updateViewForRunStatus(state: State) {
+    runStatusDiv.textContent = statusDescription(state);
 
     runButton.disabled = state.runStatus !== "idle"
-    stdinInput.disabled = state.runStatus === "idle"
+    stdinInput.disabled = state.runStatus !== "running"
 
     // Hide placeholder when disabled
     if (stdinInput.disabled) {

--- a/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
+++ b/protocol/src/main/java/uk/danielgooding/kokaplayground/protocol/CompileAndRunStream.java
@@ -106,6 +106,18 @@ public class CompileAndRunStream {
             }
         }
 
+        @JsonTypeName("starting-run")
+        public static final class StartingRun extends Message {
+            @JsonCreator
+            public StartingRun() {
+            }
+
+            @Override
+            public String toString() {
+                return "StartingRun";
+            }
+        }
+
         @JsonTypeName("running")
         public static final class Running extends Message {
             @JsonCreator
@@ -114,7 +126,7 @@ public class CompileAndRunStream {
 
             @Override
             public String toString() {
-                return "StartingCompilation";
+                return "Running";
             }
         }
 


### PR DESCRIPTION
Add a @type field, flatten unnecessary nesting. This enables using switches in client code.