### PR TITLE
Fix hanging on bwrap issue

### DIFF
--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/Subprocess.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/Subprocess.java
@@ -77,7 +77,7 @@ public class Subprocess {
         return CancellableFuture.supplyAsync(canceler -> {
             try {
                 Process process = processBuilder.start();
-                canceler.setOnCancel(process::destroy);
+                canceler.setOnCancel(process::destroyForcibly);
                 onStart.call(null);
 
 

--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/Subprocess.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/Subprocess.java
@@ -101,6 +101,7 @@ public class Subprocess {
                         // this thread will always terminate as the write call will
                         // throw once the stream is closed
                         // this simply means the process didn't eat all of toStdin
+                        canceler.cancel();
                     }
                 });
 
@@ -120,6 +121,7 @@ public class Subprocess {
                 return OrCancelled.ok(new Output(exitCode, null, stderr));
 
             } catch (InterruptedException | IOException e) {
+                canceler.cancel();
                 throw new RuntimeException(e);
             } catch (CancelledException e) {
                 return OrCancelled.cancelled();


### PR DESCRIPTION
Ensure we force kill subprocess when cancelling run, to avoid blocking forever in an unclean shutdown case.

The bubblewrap child process waits on an eventfd for its parent before closing. However sometimes the parent is killed before writing the event, so the child stays forever, blocking our worker thread.