### PR TITLE
Make LocalExeStore thread-safe

### DIFF
--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/exe/LocalExeStore.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/exe/LocalExeStore.java
@@ -22,7 +22,7 @@ public class LocalExeStore implements ExeStore {
         directory = Files.createTempDirectory(inDirectory, "exe-store");
     }
 
-    private ExeHandle freshHandle() {
+    private synchronized ExeHandle freshHandle() {
         Path path = directory.resolve(String.format("exe-%d", nextId++));
         return new ExeHandle(path.toString());
     }


### PR DESCRIPTION
Previously a race could mean we hand-out duplicate exe-handles.