### PR TITLE
Implement load-tester

### DIFF
--- a/load-tester/.gitignore
+++ b/load-tester/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/load-tester/package-lock.json
+++ b/load-tester/package-lock.json
@@ -1,0 +1,122 @@
+{
+  "name": "load-tester",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "load-tester",
+      "version": "1.0.0",
+      "dependencies": {
+        "command-line-args": "^6.0.1"
+      },
+      "devDependencies": {
+        "@types/command-line-args": "^5.2.3",
+        "@types/node": "^24.3.1",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/load-tester/package-lock.json
+++ b/load-tester/package-lock.json
@@ -8,11 +8,13 @@
       "name": "load-tester",
       "version": "1.0.0",
       "dependencies": {
-        "command-line-args": "^6.0.1"
+        "command-line-args": "^6.0.1",
+        "stats-lite": "^2.2.0"
       },
       "devDependencies": {
         "@types/command-line-args": "^5.2.3",
         "@types/node": "^24.3.1",
+        "@types/stats-lite": "^2.2.2",
         "typescript": "^5.9.2"
       }
     },
@@ -32,6 +34,13 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/stats-lite": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/stats-lite/-/stats-lite-2.2.2.tgz",
+      "integrity": "sha512-T+bzT53cbPbE0hMlCNZux1QuH6hQFNHIwRMTQCu3YPG0W7XUfeoULHl+TehJCjaxQx8cz4wlg5oQsOyG9LvZmA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-back": {
       "version": "6.2.2",
@@ -82,11 +91,29 @@
         }
       }
     },
+    "node_modules/isnumber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
+      "integrity": "sha512-JLiSz/zsZcGFXPrB4I/AGBvtStkt+8QmksyZBZnVXnnK9XdTEyz0tX8CRYljtwYDuIuZzih6DpHQdi+3Q6zHPw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
+    },
+    "node_modules/stats-lite": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
+      "integrity": "sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==",
+      "license": "MIT",
+      "dependencies": {
+        "isnumber": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=2.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.2",

--- a/load-tester/package.json
+++ b/load-tester/package.json
@@ -10,9 +10,11 @@
   "devDependencies": {
     "@types/command-line-args": "^5.2.3",
     "@types/node": "^24.3.1",
+    "@types/stats-lite": "^2.2.2",
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "command-line-args": "^6.0.1"
+    "command-line-args": "^6.0.1",
+    "stats-lite": "^2.2.0"
   }
 }

--- a/load-tester/package.json
+++ b/load-tester/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "load-tester",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/app.ts",
+  "scripts": {
+    "build": "tsc",
+    "run": "tsc && node dist/app.js"
+  },
+  "devDependencies": {
+    "@types/command-line-args": "^5.2.3",
+    "@types/node": "^24.3.1",
+    "typescript": "^5.9.2"
+  },
+  "dependencies": {
+    "command-line-args": "^6.0.1"
+  }
+}

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -1,32 +1,16 @@
 import commandLineArgs from 'command-line-args'
-import { sendCompileAndRunRequest, sendCompileRequest } from './requestor.js'
+import { CompileRequestor, CompileAndRunRequestor, Requestor } from './requestor.js'
 import LoadTester from './loadtester.js'
-import type {RequestDetails} from './outcomes.js'
 
 type cli_params = {
     url: URL,
     requestsPerSecond: number,
     printRawStats: boolean,
-    service: 'compile-and-run' | 'compile'
+    requestor: Requestor,
 }
 
 function main(options: cli_params) {
-    let sendRequest;
-    switch (options.service) {
-        case 'compile-and-run':
-            sendRequest = sendCompileAndRunRequest
-            break
-        case 'compile':
-            sendRequest = sendCompileRequest
-            break
-        default:
-            throw new Error(`Unsupported service: ${options.service}`)
-    }
-    // TODO: requestor should be a class with a request() method
-    const requestor =
-        (onOutcome: (summary: RequestDetails) => void) => sendRequest(options.url, onOutcome)
-
-    const loadTester = new LoadTester(options.requestsPerSecond, requestor, options.printRawStats)
+    const loadTester = new LoadTester(options.requestsPerSecond, options.requestor, options.printRawStats)
     loadTester.run()
 }
 
@@ -39,11 +23,24 @@ function cli() {
     ]
 
     const options = commandLineArgs(optionDefinitions)
+
+    let requestor: Requestor;
+    switch (options.service) {
+        case 'compile-and-run':
+            requestor = new CompileAndRunRequestor(options.url)
+            break
+        case 'compile':
+            requestor = new CompileRequestor(options.url)
+            break
+        default:
+            throw new Error(`Unsupported service: ${options.service}`)
+    }
+
     const params: cli_params = {
         url: options.url,
         requestsPerSecond: options.rps,
         printRawStats: options['print-raw-stats'],
-        service: options.service
+        requestor
     }
     main(params)
 }

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -6,13 +6,14 @@ import type {RequestDetails} from './outcomes.js'
 type cli_params = {
     url: URL,
     requestsPerSecond: number,
+    printRawStats: boolean,
 }
 
 function main(options: cli_params) {
     const requestor =
         (onOutcome: (summary: RequestDetails) => void) => sendRequest(options.url, onOutcome)
 
-    const loadTester = new LoadTester(options.requestsPerSecond, requestor)
+    const loadTester = new LoadTester(options.requestsPerSecond, requestor, options.printRawStats)
     loadTester.run()
 }
 
@@ -20,12 +21,14 @@ function cli() {
     const optionDefinitions = [
         { name: 'url', type: (url: string) => new URL(url) },
         { name: 'rps', type: Number, defaultValue: 1 },
+        { name: 'print-raw-stats', type: Boolean, defaultValue: false },
     ]
 
     const options = commandLineArgs(optionDefinitions)
     const params: cli_params = {
         url: options.url,
         requestsPerSecond: options.rps,
+        printRawStats: options['print-raw-stats']
     }
     main(params)
 }

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -1,0 +1,29 @@
+import commandLineArgs from 'command-line-args'
+
+function main(options: any) {
+    console.log(options);
+    const ws = new WebSocket(options.url);
+
+    ws.onopen = () => {
+        console.log('connected');
+        ws.send(JSON.stringify({
+            '@type': 'compile-and-run',
+            'code': 'fun main() { println-int(3 * 4); }'
+        }));
+    }
+
+    ws.onmessage = (e) => {
+        const message = JSON.parse(e.data);
+        console.log('received message', message);
+    }
+
+    ws.onclose = () => {
+        console.log('closed');
+    }
+}
+
+const optionDefinitions = [
+    { name: 'url', type: String, required: true },
+]
+
+main(commandLineArgs(optionDefinitions))

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -1,82 +1,19 @@
 import commandLineArgs from 'command-line-args'
-
-type RequestOutcome = 'ok' | 'client error' | 'server error'
-type RequestSummary = {
-    outcome: RequestOutcome
-    toOpenMs?: number,
-    toFirstResponseMs?: number,
-    toCloseMs?: number,
-}
-
-function send_request(
-    url: URL,
-    onComplete: (requestSummary: RequestSummary) => void,
-) {
-    const ws = new WebSocket(url);
-
-    const openTime = Date.now()
-    let requestSummary: Partial<RequestSummary> = {}
-
-    ws.onopen = () => {
-        requestSummary.toOpenMs = Date.now() - openTime;
-        ws.send(JSON.stringify({
-            '@type': 'compile-and-run',
-            'code': 'fun main() { println-int(3 * 4); }'
-        }));
-    }
-
-    const onClose = (outcome: RequestOutcome) => {
-        if (requestSummary.outcome) return; // already closed
-        requestSummary.toCloseMs = Date.now() - openTime;
-        onComplete({ ...requestSummary, outcome: outcome });
-    }
-
-    ws.onmessage = (e) => {
-        requestSummary.toFirstResponseMs = Date.now() - openTime;
-        const message = JSON.parse(e.data);
-        if (message['@type'] === 'error') {
-            onClose('client error')
-        }
-    }
-
-    ws.onclose = (e) => {
-        // ok is NORMAL or GOING_AWAY
-        const closeOk = e.code == 1000 || e.code == 1001;
-        onClose(closeOk ? 'ok' : 'server error');
-    }
-}
+import {sendRequest} from './requestor.js'
+import LoadTester from './loadtester.js'
+import type {RequestDetails} from './outcomes.js'
 
 type cli_params = {
     url: URL,
-    requests_per_second: number,
+    requestsPerSecond: number,
 }
 
 function main(options: cli_params) {
+    const requestor =
+        (onOutcome: (summary: RequestDetails) => void) => sendRequest(options.url, onOutcome)
 
-    let totalCount = 0
-    const outcomeCounts = new Map<RequestOutcome, number>()
-
-    const onComplete = (summary: RequestSummary) => {
-        outcomeCounts.set(summary.outcome,
-            (outcomeCounts.get(summary.outcome) ?? 0) + 1);
-        totalCount += 1
-    }
-
-    setInterval(() => {
-        send_request(options.url, onComplete)
-    }, 1000 / options.requests_per_second)
-
-    const updatesPerSecond = 5
-    setInterval(() => {
-        const outcomeFractions: [RequestOutcome, string][] =
-            Array.from(outcomeCounts.entries())
-                .map(
-                    ([outcome, count]: [RequestOutcome, number]) => {
-                        return [outcome, (count / totalCount * 100).toFixed(1)];
-                    })
-        console.log(new Map<RequestOutcome, string>(outcomeFractions))
-
-    }, 1000 / updatesPerSecond)
+    const loadTester = new LoadTester(options.requestsPerSecond, requestor)
+    loadTester.run()
 }
 
 function cli() {
@@ -88,7 +25,7 @@ function cli() {
     const options = commandLineArgs(optionDefinitions)
     const params: cli_params = {
         url: options.url,
-        requests_per_second: options.rps,
+        requestsPerSecond: options.rps,
     }
     main(params)
 }

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -1,5 +1,5 @@
 import commandLineArgs from 'command-line-args'
-import {sendRequest} from './requestor.js'
+import {sendCompileAndRunRequest} from './requestor.js'
 import LoadTester from './loadtester.js'
 import type {RequestDetails} from './outcomes.js'
 
@@ -11,7 +11,7 @@ type cli_params = {
 
 function main(options: cli_params) {
     const requestor =
-        (onOutcome: (summary: RequestDetails) => void) => sendRequest(options.url, onOutcome)
+        (onOutcome: (summary: RequestDetails) => void) => sendCompileAndRunRequest(options.url, onOutcome)
 
     const loadTester = new LoadTester(options.requestsPerSecond, requestor, options.printRawStats)
     loadTester.run()

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -1,5 +1,5 @@
 import commandLineArgs from 'command-line-args'
-import {sendCompileAndRunRequest} from './requestor.js'
+import { sendCompileAndRunRequest, sendCompileRequest } from './requestor.js'
 import LoadTester from './loadtester.js'
 import type {RequestDetails} from './outcomes.js'
 
@@ -7,11 +7,24 @@ type cli_params = {
     url: URL,
     requestsPerSecond: number,
     printRawStats: boolean,
+    service: 'compile-and-run' | 'compile'
 }
 
 function main(options: cli_params) {
+    let sendRequest;
+    switch (options.service) {
+        case 'compile-and-run':
+            sendRequest = sendCompileAndRunRequest
+            break
+        case 'compile':
+            sendRequest = sendCompileRequest
+            break
+        default:
+            throw new Error(`Unsupported service: ${options.service}`)
+    }
+    // TODO: requestor should be a class with a request() method
     const requestor =
-        (onOutcome: (summary: RequestDetails) => void) => sendCompileAndRunRequest(options.url, onOutcome)
+        (onOutcome: (summary: RequestDetails) => void) => sendRequest(options.url, onOutcome)
 
     const loadTester = new LoadTester(options.requestsPerSecond, requestor, options.printRawStats)
     loadTester.run()
@@ -22,13 +35,15 @@ function cli() {
         { name: 'url', type: (url: string) => new URL(url) },
         { name: 'rps', type: Number, defaultValue: 1 },
         { name: 'print-raw-stats', type: Boolean, defaultValue: false },
+        { name: 'service', type: String }
     ]
 
     const options = commandLineArgs(optionDefinitions)
     const params: cli_params = {
         url: options.url,
         requestsPerSecond: options.rps,
-        printRawStats: options['print-raw-stats']
+        printRawStats: options['print-raw-stats'],
+        service: options.service
     }
     main(params)
 }

--- a/load-tester/src/app.ts
+++ b/load-tester/src/app.ts
@@ -1,29 +1,96 @@
 import commandLineArgs from 'command-line-args'
 
-function main(options: any) {
-    console.log(options);
-    const ws = new WebSocket(options.url);
+type RequestOutcome = 'ok' | 'client error' | 'server error'
+type RequestSummary = {
+    outcome: RequestOutcome
+    toOpenMs?: number,
+    toFirstResponseMs?: number,
+    toCloseMs?: number,
+}
+
+function send_request(
+    url: URL,
+    onComplete: (requestSummary: RequestSummary) => void,
+) {
+    const ws = new WebSocket(url);
+
+    const openTime = Date.now()
+    let requestSummary: Partial<RequestSummary> = {}
 
     ws.onopen = () => {
-        console.log('connected');
+        requestSummary.toOpenMs = Date.now() - openTime;
         ws.send(JSON.stringify({
             '@type': 'compile-and-run',
             'code': 'fun main() { println-int(3 * 4); }'
         }));
     }
 
-    ws.onmessage = (e) => {
-        const message = JSON.parse(e.data);
-        console.log('received message', message);
+    const onClose = (outcome: RequestOutcome) => {
+        if (requestSummary.outcome) return; // already closed
+        requestSummary.toCloseMs = Date.now() - openTime;
+        onComplete({ ...requestSummary, outcome: outcome });
     }
 
-    ws.onclose = () => {
-        console.log('closed');
+    ws.onmessage = (e) => {
+        requestSummary.toFirstResponseMs = Date.now() - openTime;
+        const message = JSON.parse(e.data);
+        if (message['@type'] === 'error') {
+            onClose('client error')
+        }
+    }
+
+    ws.onclose = (e) => {
+        // ok is NORMAL or GOING_AWAY
+        const closeOk = e.code == 1000 || e.code == 1001;
+        onClose(closeOk ? 'ok' : 'server error');
     }
 }
 
-const optionDefinitions = [
-    { name: 'url', type: String, required: true },
-]
+type cli_params = {
+    url: URL,
+    requests_per_second: number,
+}
 
-main(commandLineArgs(optionDefinitions))
+function main(options: cli_params) {
+
+    let totalCount = 0
+    const outcomeCounts = new Map<RequestOutcome, number>()
+
+    const onComplete = (summary: RequestSummary) => {
+        outcomeCounts.set(summary.outcome,
+            (outcomeCounts.get(summary.outcome) ?? 0) + 1);
+        totalCount += 1
+    }
+
+    setInterval(() => {
+        send_request(options.url, onComplete)
+    }, 1000 / options.requests_per_second)
+
+    const updatesPerSecond = 5
+    setInterval(() => {
+        const outcomeFractions: [RequestOutcome, string][] =
+            Array.from(outcomeCounts.entries())
+                .map(
+                    ([outcome, count]: [RequestOutcome, number]) => {
+                        return [outcome, (count / totalCount * 100).toFixed(1)];
+                    })
+        console.log(new Map<RequestOutcome, string>(outcomeFractions))
+
+    }, 1000 / updatesPerSecond)
+}
+
+function cli() {
+    const optionDefinitions = [
+        { name: 'url', type: (url: string) => new URL(url) },
+        { name: 'rps', type: Number, defaultValue: 1 },
+    ]
+
+    const options = commandLineArgs(optionDefinitions)
+    const params: cli_params = {
+        url: options.url,
+        requests_per_second: options.rps,
+    }
+    main(params)
+}
+
+cli()

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -2,43 +2,94 @@ import type { RequestDetails, RequestOutcome } from './outcomes.js'
 
 type Requestor = (onComplete: (summary: RequestDetails) => void) => void
 
+class BucketSummary {
+    totalCount = 0
+    outcomeCounts = new Map<RequestOutcome, number>()
+
+    addSummary(summary: RequestDetails) {
+        this.outcomeCounts.set(summary.outcome,
+            (this.outcomeCounts.get(summary.outcome) ?? 0) + 1);
+        this.totalCount += 1
+    }
+
+    getFractions(): Map<RequestOutcome, string> {
+        const outcomeFractions = new Map<RequestOutcome, string>
+        for (const [outcome, count] of this.outcomeCounts.entries()) {
+            outcomeFractions.set(outcome, ((count / this.totalCount) * 100).toFixed(1))
+        }
+        return  outcomeFractions
+    }
+
+    static combine(buckets: BucketSummary[]) {
+        const totalBucket = new BucketSummary()
+        for (const bucket of buckets) {
+            totalBucket.totalCount += bucket.totalCount
+            for (const [outcome, count] of bucket.outcomeCounts) {
+                totalBucket.outcomeCounts.set(outcome,
+                    (totalBucket.outcomeCounts.get(outcome) ?? 0) + count)
+            }
+        }
+        return totalBucket
+    }
+}
+
 export default class LoadTester {
     readonly requestsPerSecond: number
     readonly sendRequest: Requestor
 
-    totalCount = 0
-    outcomeCounts = new Map<RequestOutcome, number>()
+    readonly windowSeconds: number
+    readonly bucketsPerWindow: number
 
-    constructor(requestsPerSecond: number, sendRequest: Requestor) {
+    // the last bucket is currently being populated
+    // its time window has not yet fully passed
+    // so it shouldn't be used in calculations
+    buckets: BucketSummary[]
+
+    constructor(requestsPerSecond: number, sendRequest: Requestor, windowSeconds: number = 10) {
         this.requestsPerSecond = requestsPerSecond
         this.sendRequest = sendRequest
+
+        this.bucketsPerWindow = 10
+        this.windowSeconds = windowSeconds
+
+        this.buckets = [new BucketSummary()]
     }
 
     printSummary() {
-        const outcomeFractions: [RequestOutcome, string][] =
-            Array.from(this.outcomeCounts.entries())
-                .map(
-                    ([outcome, count]: [RequestOutcome, number]) => {
-                        return [outcome, (count / this.totalCount * 100).toFixed(1)];
-                    })
 
-        console.log(new Map<RequestOutcome, string>(outcomeFractions))
+        // ignore the initial incomplete bucket
+        const allWindowBuckets = this.buckets.slice(0, this.buckets.length - 1)
+        const windowBucket = BucketSummary.combine(allWindowBuckets)
+        const windowSeconds = allWindowBuckets.length / this.bucketsPerWindow * this.windowSeconds
+
+        const outcomeFractions = windowBucket.getFractions()
+        const effectiveRPS = (windowBucket.outcomeCounts.get('ok') ?? 0) / windowSeconds
+
+        console.log({
+            outcomeFractions,
+            effectiveRPS,
+        })
     }
 
     run(): void {
-        const onComplete = (summary: RequestDetails) => {
-            this.outcomeCounts.set(summary.outcome,
-                (this.outcomeCounts.get(summary.outcome) ?? 0) + 1);
-            this.totalCount += 1
+        const onComplete = (details: RequestDetails) => {
+            this.buckets[this.buckets.length - 1].addSummary(details)
         }
 
+        // window shift loop
+        setInterval(() => {
+            this.buckets.push(new BucketSummary())
+            if (this.buckets.length > this.bucketsPerWindow + 1) {
+                this.buckets.shift()
+            }
+
+            this.printSummary()
+
+        }, 1000 * this.windowSeconds / this.bucketsPerWindow)
+
+        // request loop
         setInterval(() => {
             this.sendRequest(onComplete)
         }, 1000 / this.requestsPerSecond)
-
-        const updatesPerSecond = 5
-        setInterval(() => {
-            this.printSummary()
-        }, 1000 / updatesPerSecond)
     }
 }

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -1,4 +1,4 @@
-import type { RequestDetails, RequestEvent, RequestOutcome } from './outcomes.js'
+import type { RequestDetails, RequestOutcome } from './outcomes.js'
 import stats from 'stats-lite'
 
 type Requestor = (onComplete: (summary: RequestDetails) => void) => void
@@ -6,7 +6,7 @@ type Requestor = (onComplete: (summary: RequestDetails) => void) => void
 class BucketSummary {
     totalCount = 0
     outcomeCounts = new Map<RequestOutcome, number>()
-    eachOkEventLatencySeconds: Map<RequestEvent, Array<number>> = new Map<RequestEvent, Array<number>>()
+    eachOkEventLatencySeconds: Map<string, Array<number>> = new Map<string, Array<number>>()
 
     addSummary(summary: RequestDetails) {
         this.outcomeCounts.set(summary.outcome,
@@ -94,7 +94,7 @@ export default class LoadTester {
         const concurrency = totalOkLatencySeconds / windowSeconds
 
         const medianOkLatencyByEvent =
-            new Map<RequestEvent, string>(
+            new Map<string, string>(
             Array.from(windowBucket.eachOkEventLatencySeconds)
                 .map(([event, latencies]) =>
                     [event, stats.median(latencies).toFixed(3)]))

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -1,7 +1,6 @@
 import type { RequestDetails, RequestOutcome } from './outcomes.js'
+import { Requestor } from './requestor.js'
 import stats from 'stats-lite'
-
-type Requestor = (onComplete: (summary: RequestDetails) => void) => void
 
 class BucketSummary {
     totalCount = 0
@@ -56,7 +55,7 @@ class BucketSummary {
 
 export default class LoadTester {
     readonly requestsPerSecond: number
-    readonly sendRequest: Requestor
+    readonly requestor: Requestor
 
     readonly windowSeconds: number = 10
     readonly bucketsPerWindow: number = 10
@@ -68,9 +67,9 @@ export default class LoadTester {
     // so it shouldn't be used in calculations
     buckets: BucketSummary[]
 
-    constructor(requestsPerSecond: number, sendRequest: Requestor, printRawStats: boolean = false) {
+    constructor(requestsPerSecond: number, requestor: Requestor, printRawStats: boolean = false) {
         this.requestsPerSecond = requestsPerSecond
-        this.sendRequest = sendRequest
+        this.requestor = requestor
         this.printRawStats = printRawStats
 
         this.buckets = [new BucketSummary()]
@@ -125,7 +124,7 @@ export default class LoadTester {
 
         // request loop
         setInterval(() => {
-            this.sendRequest(onComplete)
+            this.requestor.request(onComplete)
         }, 1000 / this.requestsPerSecond)
     }
 }

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -5,11 +5,17 @@ type Requestor = (onComplete: (summary: RequestDetails) => void) => void
 class BucketSummary {
     totalCount = 0
     outcomeCounts = new Map<RequestOutcome, number>()
+    totalOkLatencyMs: number = 0
 
     addSummary(summary: RequestDetails) {
         this.outcomeCounts.set(summary.outcome,
             (this.outcomeCounts.get(summary.outcome) ?? 0) + 1);
         this.totalCount += 1
+
+        if (summary.outcome === 'ok') {
+            // won't be undefined if request completed
+            this.totalOkLatencyMs += summary.toCloseMs ?? 0
+        }
     }
 
     getFractions(): Map<RequestOutcome, string> {
@@ -17,13 +23,14 @@ class BucketSummary {
         for (const [outcome, count] of this.outcomeCounts.entries()) {
             outcomeFractions.set(outcome, ((count / this.totalCount) * 100).toFixed(1))
         }
-        return  outcomeFractions
+        return outcomeFractions
     }
 
     static combine(buckets: BucketSummary[]) {
         const totalBucket = new BucketSummary()
         for (const bucket of buckets) {
             totalBucket.totalCount += bucket.totalCount
+            totalBucket.totalOkLatencyMs += bucket.totalOkLatencyMs
             for (const [outcome, count] of bucket.outcomeCounts) {
                 totalBucket.outcomeCounts.set(outcome,
                     (totalBucket.outcomeCounts.get(outcome) ?? 0) + count)
@@ -37,20 +44,20 @@ export default class LoadTester {
     readonly requestsPerSecond: number
     readonly sendRequest: Requestor
 
-    readonly windowSeconds: number
-    readonly bucketsPerWindow: number
+    readonly windowSeconds: number = 10
+    readonly bucketsPerWindow: number = 10
+
+    readonly printRawStats: boolean
 
     // the last bucket is currently being populated
     // its time window has not yet fully passed
     // so it shouldn't be used in calculations
     buckets: BucketSummary[]
 
-    constructor(requestsPerSecond: number, sendRequest: Requestor, windowSeconds: number = 10) {
+    constructor(requestsPerSecond: number, sendRequest: Requestor, printRawStats: boolean = false) {
         this.requestsPerSecond = requestsPerSecond
         this.sendRequest = sendRequest
-
-        this.bucketsPerWindow = 10
-        this.windowSeconds = windowSeconds
+        this.printRawStats = printRawStats
 
         this.buckets = [new BucketSummary()]
     }
@@ -62,12 +69,19 @@ export default class LoadTester {
         const windowBucket = BucketSummary.combine(allWindowBuckets)
         const windowSeconds = allWindowBuckets.length / this.bucketsPerWindow * this.windowSeconds
 
+        if (this.printRawStats) {
+            console.log(windowBucket)
+        }
+
         const outcomeFractions = windowBucket.getFractions()
         const effectiveRPS = (windowBucket.outcomeCounts.get('ok') ?? 0) / windowSeconds
+
+        const concurrency = windowBucket.totalOkLatencyMs / (windowSeconds * 1000)
 
         console.log({
             outcomeFractions,
             effectiveRPS,
+            concurrency
         })
     }
 

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -15,7 +15,7 @@ class BucketSummary {
 
         if (summary.outcome === 'ok') {
             // won't be undefined if request completed
-            this.eachOkLatencySeconds.push(summary.toCloseSeconds as number)
+            this.eachOkLatencySeconds.push(summary.toEventSeconds.get('closed') as number)
         }
     }
 

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -1,0 +1,44 @@
+import type { RequestDetails, RequestOutcome } from './outcomes.js'
+
+type Requestor = (onComplete: (summary: RequestDetails) => void) => void
+
+export default class LoadTester {
+    readonly requestsPerSecond: number
+    readonly sendRequest: Requestor
+
+    totalCount = 0
+    outcomeCounts = new Map<RequestOutcome, number>()
+
+    constructor(requestsPerSecond: number, sendRequest: Requestor) {
+        this.requestsPerSecond = requestsPerSecond
+        this.sendRequest = sendRequest
+    }
+
+    printSummary() {
+        const outcomeFractions: [RequestOutcome, string][] =
+            Array.from(this.outcomeCounts.entries())
+                .map(
+                    ([outcome, count]: [RequestOutcome, number]) => {
+                        return [outcome, (count / this.totalCount * 100).toFixed(1)];
+                    })
+
+        console.log(new Map<RequestOutcome, string>(outcomeFractions))
+    }
+
+    run(): void {
+        const onComplete = (summary: RequestDetails) => {
+            this.outcomeCounts.set(summary.outcome,
+                (this.outcomeCounts.get(summary.outcome) ?? 0) + 1);
+            this.totalCount += 1
+        }
+
+        setInterval(() => {
+            this.sendRequest(onComplete)
+        }, 1000 / this.requestsPerSecond)
+
+        const updatesPerSecond = 5
+        setInterval(() => {
+            this.printSummary()
+        }, 1000 / updatesPerSecond)
+    }
+}

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -19,12 +19,12 @@ class BucketSummary {
         }
     }
 
-    getFractions(): Map<RequestOutcome, string> {
-        const outcomeFractions = new Map<RequestOutcome, string>
+    getPercentages(): Map<RequestOutcome, string> {
+        const outcomePercentages = new Map<RequestOutcome, string>
         for (const [outcome, count] of this.outcomeCounts.entries()) {
-            outcomeFractions.set(outcome, ((count / this.totalCount) * 100).toFixed(1))
+            outcomePercentages.set(outcome, ((count / this.totalCount) * 100).toFixed(1))
         }
-        return outcomeFractions
+        return outcomePercentages
     }
 
     static combine(buckets: BucketSummary[]) {
@@ -74,7 +74,7 @@ export default class LoadTester {
             console.log(windowBucket)
         }
 
-        const outcomeFractions = windowBucket.getFractions()
+        const outcomePercentages = windowBucket.getPercentages()
         const effectiveRPS = (windowBucket.outcomeCounts.get('ok') ?? 0) / windowSeconds
 
         const totalOkLatencySeconds = stats.sum(windowBucket.eachOkLatencySeconds)
@@ -82,10 +82,10 @@ export default class LoadTester {
 
 
         console.log({
-            outcomeFractions,
-            effectiveRPS,
-            concurrency,
-            medianOkLatencySeconds: stats.median(windowBucket.eachOkLatencySeconds),
+            outcomePercentages,
+            effectiveRPS: effectiveRPS.toFixed(0),
+            concurrency: concurrency.toFixed(1),
+            medianOkLatencySeconds: stats.median(windowBucket.eachOkLatencySeconds).toFixed(3),
         })
     }
 

--- a/load-tester/src/loadtester.ts
+++ b/load-tester/src/loadtester.ts
@@ -93,14 +93,17 @@ export default class LoadTester {
         const totalOkLatencySeconds = stats.sum(windowBucket.eachOkEventLatencySeconds.get('closed') ?? [])
         const concurrency = totalOkLatencySeconds / windowSeconds
 
-        const medianOkLatencySeconds =
-            stats.median(windowBucket.eachOkEventLatencySeconds.get('closed') ?? [])
+        const medianOkLatencyByEvent =
+            new Map<RequestEvent, string>(
+            Array.from(windowBucket.eachOkEventLatencySeconds)
+                .map(([event, latencies]) =>
+                    [event, stats.median(latencies).toFixed(3)]))
 
         console.log({
             outcomePercentages,
             effectiveRPS: effectiveRPS.toFixed(0),
             concurrency: concurrency.toFixed(1),
-            medianOkLatencySeconds: medianOkLatencySeconds.toFixed(3),
+            medianOkLatencyByEvent,
         })
     }
 

--- a/load-tester/src/outcomes.ts
+++ b/load-tester/src/outcomes.ts
@@ -1,7 +1,7 @@
 export type RequestOutcome = 'ok' | 'client error' | 'server error'
 export type RequestDetails = {
     outcome: RequestOutcome
-    toOpenMs?: number,
-    toFirstResponseMs?: number,
-    toCloseMs?: number,
+    toOpenSeconds?: number,
+    toFirstResponseSeconds?: number,
+    toCloseSeconds?: number,
 }

--- a/load-tester/src/outcomes.ts
+++ b/load-tester/src/outcomes.ts
@@ -1,0 +1,7 @@
+export type RequestOutcome = 'ok' | 'client error' | 'server error'
+export type RequestDetails = {
+    outcome: RequestOutcome
+    toOpenMs?: number,
+    toFirstResponseMs?: number,
+    toCloseMs?: number,
+}

--- a/load-tester/src/outcomes.ts
+++ b/load-tester/src/outcomes.ts
@@ -1,6 +1,6 @@
 export type RequestOutcome = 'ok' | 'client error' | 'server error'
-export type RequestEvent = 'opened' | 'first-response' | 'requested-run' | 'running' | 'closed'
+export type RequestEvent = 'opened' | 'closed'
 export type RequestDetails = {
     outcome: RequestOutcome,
-    toEventSeconds: Map<RequestEvent, number>
+    toEventSeconds: Map<RequestEvent | string, number>
 }

--- a/load-tester/src/outcomes.ts
+++ b/load-tester/src/outcomes.ts
@@ -1,7 +1,6 @@
 export type RequestOutcome = 'ok' | 'client error' | 'server error'
+export type RequestEvent = 'opened' | 'first-response' | 'requested-run' | 'running' | 'closed'
 export type RequestDetails = {
-    outcome: RequestOutcome
-    toOpenSeconds?: number,
-    toFirstResponseSeconds?: number,
-    toCloseSeconds?: number,
+    outcome: RequestOutcome,
+    toEventSeconds: Map<RequestEvent, number>
 }

--- a/load-tester/src/outcomes.ts
+++ b/load-tester/src/outcomes.ts
@@ -1,4 +1,4 @@
-export type RequestOutcome = 'ok' | 'client error' | 'server error'
+export type RequestOutcome = 'ok' | 'client error' | 'server error' | 'transport error'
 export type RequestEvent = 'opened' | 'closed'
 export type RequestDetails = {
     outcome: RequestOutcome,

--- a/load-tester/src/requestor.ts
+++ b/load-tester/src/requestor.ts
@@ -1,13 +1,13 @@
 import type { RequestDetails, RequestOutcome, RequestEvent } from './outcomes.js'
 
-export function sendRequest(
+export function sendCompileAndRunRequest(
     url: URL,
     onComplete: (requestDetails: RequestDetails) => void,
 ) {
     const ws = new WebSocket(url);
 
     const openTime = Date.now()
-    const toEventSeconds = new Map<RequestEvent, number>()
+    const toEventSeconds = new Map<(RequestEvent | 'first-response' | 'requested-run' | 'running'), number>()
 
     ws.onopen = () => {
         toEventSeconds.set('opened', (Date.now() - openTime) / 1000)

--- a/load-tester/src/requestor.ts
+++ b/load-tester/src/requestor.ts
@@ -1,54 +1,71 @@
 import type { RequestDetails, RequestOutcome, RequestEvent } from './outcomes.js'
 
-export function sendCompileAndRunRequest(
-    url: URL,
-    onComplete: (requestDetails: RequestDetails) => void,
-) {
-    const ws = new WebSocket(url);
+export abstract class Requestor {
+    url: URL
 
-    const openTime = Date.now()
-    const toEventSeconds = new Map<(RequestEvent | 'first-response' | 'requested-run' | 'running'), number>()
-
-    ws.onopen = () => {
-        toEventSeconds.set('opened', (Date.now() - openTime) / 1000)
-        ws.send(JSON.stringify({
-            '@type': 'compile-and-run',
-            'code': 'fun main() { println-int(3 * 4); }'
-        }));
+    constructor(url: URL) {
+        this.url = url
     }
 
-    const onClose = (outcome: RequestOutcome) => {
-        if (toEventSeconds.has('closed')) return;
-
-        toEventSeconds.set('closed', (Date.now() - openTime) / 1000)
-        onComplete({ toEventSeconds, outcome });
-    }
-
-    ws.onmessage = (e) => {
-        const secondsToNow = (Date.now() - openTime) / 1000
-        if (!toEventSeconds.has('first-response')) {
-            toEventSeconds.set('first-response', secondsToNow)
-        }
-        const message = JSON.parse(e.data);
-        if (message['@type'] === 'error') {
-            onClose('client error')
-        }else if (message['@type'] === 'starting-run') {
-            toEventSeconds.set('requested-run', secondsToNow)
-        }else if (message['@type'] === 'running') {
-            toEventSeconds.set('running', secondsToNow)
-        }
-    }
-
-    ws.onclose = (e) => {
-        // ok is NORMAL or GOING_AWAY
-        const closeOk = e.code == 1000 || e.code == 1001;
-        onClose(closeOk ? 'ok' : 'server error');
-    }
+    abstract request(onComplete: (summary: RequestDetails) => void): void
 }
 
-export function sendCompileRequest(
-    url: URL,
-    onComplete: (requestDetails: RequestDetails) => void
-) {
-    console.log(`request ${url} ${onComplete}`)
+export class CompileAndRunRequestor extends Requestor {
+    constructor(url: URL) {
+        super(url)
+    }
+
+    request(onComplete: (summary: RequestDetails) => void) {
+        const ws = new WebSocket(this.url);
+
+        const openTime = Date.now()
+        const toEventSeconds = new Map<(RequestEvent | 'first-response' | 'requested-run' | 'running'), number>()
+
+        ws.onopen = () => {
+            toEventSeconds.set('opened', (Date.now() - openTime) / 1000)
+            ws.send(JSON.stringify({
+                '@type': 'compile-and-run',
+                'code': 'fun main() { println-int(3 * 4); }'
+            }));
+        }
+
+        const onClose = (outcome: RequestOutcome) => {
+            if (toEventSeconds.has('closed')) return;
+
+            toEventSeconds.set('closed', (Date.now() - openTime) / 1000)
+            onComplete({ toEventSeconds, outcome });
+        }
+
+        ws.onmessage = (e) => {
+            const secondsToNow = (Date.now() - openTime) / 1000
+            if (!toEventSeconds.has('first-response')) {
+                toEventSeconds.set('first-response', secondsToNow)
+            }
+            const message = JSON.parse(e.data);
+            if (message['@type'] === 'error') {
+                onClose('client error')
+            }else if (message['@type'] === 'starting-run') {
+                toEventSeconds.set('requested-run', secondsToNow)
+            }else if (message['@type'] === 'running') {
+                toEventSeconds.set('running', secondsToNow)
+            }
+        }
+
+        ws.onclose = (e) => {
+            // ok is NORMAL or GOING_AWAY
+            const closeOk = e.code == 1000 || e.code == 1001;
+            onClose(closeOk ? 'ok' : 'server error');
+        }
+    }
+
+}
+
+export class CompileRequestor extends Requestor {
+    constructor(url: URL) {
+        super(url);
+    }
+
+    request(onComplete: (summary: RequestDetails) => void) {
+        console.log(`request ${this.url} ${onComplete}`)
+    }
 }

--- a/load-tester/src/requestor.ts
+++ b/load-tester/src/requestor.ts
@@ -45,3 +45,10 @@ export function sendCompileAndRunRequest(
         onClose(closeOk ? 'ok' : 'server error');
     }
 }
+
+export function sendCompileRequest(
+    url: URL,
+    onComplete: (requestDetails: RequestDetails) => void
+) {
+    console.log(`request ${url} ${onComplete}`)
+}

--- a/load-tester/src/requestor.ts
+++ b/load-tester/src/requestor.ts
@@ -1,4 +1,9 @@
 import type { RequestDetails, RequestOutcome, RequestEvent } from './outcomes.js'
+import http from 'http'
+
+function secondsSince(then: number): number {
+    return (Date.now() - then) / 1000
+}
 
 export abstract class Requestor {
     url: URL
@@ -22,7 +27,7 @@ export class CompileAndRunRequestor extends Requestor {
         const toEventSeconds = new Map<(RequestEvent | 'first-response' | 'requested-run' | 'running'), number>()
 
         ws.onopen = () => {
-            toEventSeconds.set('opened', (Date.now() - openTime) / 1000)
+            toEventSeconds.set('opened', secondsSince(openTime))
             ws.send(JSON.stringify({
                 '@type': 'compile-and-run',
                 'code': 'fun main() { println-int(3 * 4); }'
@@ -32,12 +37,12 @@ export class CompileAndRunRequestor extends Requestor {
         const onClose = (outcome: RequestOutcome) => {
             if (toEventSeconds.has('closed')) return;
 
-            toEventSeconds.set('closed', (Date.now() - openTime) / 1000)
+            toEventSeconds.set('closed', secondsSince(openTime))
             onComplete({ toEventSeconds, outcome });
         }
 
         ws.onmessage = (e) => {
-            const secondsToNow = (Date.now() - openTime) / 1000
+            const secondsToNow = secondsSince(openTime)
             if (!toEventSeconds.has('first-response')) {
                 toEventSeconds.set('first-response', secondsToNow)
             }
@@ -66,6 +71,62 @@ export class CompileRequestor extends Requestor {
     }
 
     request(onComplete: (summary: RequestDetails) => void) {
-        console.log(`request ${this.url} ${onComplete}`)
+        const postData = JSON.stringify({code: 'fun main() { println-int(5 * 6); }'})
+
+        if (this.url.search) {
+            throw new Error('url query params not implemented: ' + this.url.search);
+        }
+        const options = {
+            host: this.url.hostname,
+            port: this.url.port,
+            path: this.url.pathname,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(postData),
+            },
+        };
+
+        const openTime = Date.now()
+        const toEventSeconds = new Map<RequestEvent | 'connected', number>()
+        let outcome: RequestOutcome
+
+        const req = http.request(options, (res) => {
+            const statusCode = res.statusCode ?? 0;
+            if (statusCode >= 200 && statusCode < 300) {
+                outcome = 'ok';
+            }else if (statusCode >= 500 && statusCode < 600) {
+                outcome = 'server error';
+            }else {
+                outcome = 'client error';
+            }
+
+            res.on('data', (chunk) => {
+                if (outcome) return;
+
+                // responses are small - assume they fit in one chunk
+                const result = JSON.parse(chunk.toString())
+                if (!result['ok']) {
+                    outcome = 'client error';
+                }
+            })
+        })
+
+        req.on('socket', () => {
+            toEventSeconds.set('connected', secondsSince(openTime))
+        })
+        req.on('error', () => {
+            outcome = 'transport error';
+        })
+        req.on('close', () => {
+            toEventSeconds.set('closed', secondsSince(openTime))
+            onComplete({
+                outcome: outcome ?? 'server error',
+                toEventSeconds
+            })
+        })
+
+        req.write(postData);
+        req.end();
     }
 }

--- a/load-tester/src/requestor.ts
+++ b/load-tester/src/requestor.ts
@@ -1,0 +1,39 @@
+import type { RequestDetails, RequestOutcome } from './outcomes.js'
+
+export function sendRequest(
+    url: URL,
+    onComplete: (RequestDetails: RequestDetails) => void,
+) {
+    const ws = new WebSocket(url);
+
+    const openTime = Date.now()
+    let RequestDetails: Partial<RequestDetails> = {}
+
+    ws.onopen = () => {
+        RequestDetails.toOpenMs = Date.now() - openTime;
+        ws.send(JSON.stringify({
+            '@type': 'compile-and-run',
+            'code': 'fun main() { println-int(3 * 4); }'
+        }));
+    }
+
+    const onClose = (outcome: RequestOutcome) => {
+        if (RequestDetails.outcome) return; // already closed
+        RequestDetails.toCloseMs = Date.now() - openTime;
+        onComplete({ ...RequestDetails, outcome: outcome });
+    }
+
+    ws.onmessage = (e) => {
+        RequestDetails.toFirstResponseMs = Date.now() - openTime;
+        const message = JSON.parse(e.data);
+        if (message['@type'] === 'error') {
+            onClose('client error')
+        }
+    }
+
+    ws.onclose = (e) => {
+        // ok is NORMAL or GOING_AWAY
+        const closeOk = e.code == 1000 || e.code == 1001;
+        onClose(closeOk ? 'ok' : 'server error');
+    }
+}

--- a/load-tester/tsconfig.json
+++ b/load-tester/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "sourceMap": true,
+    "outDir": "dist",
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Create a CLI load-tester suitable for sending requests at some target rate, measuring outcomes, and latencies for different points in the response.

Example usage: `npm run run -- --url ws://localhost:80/ws/compile-and-run --service compile-and-run --rps 50`
```javascript
{
  outcomePercentages: Map(1) { 'ok' => '100.0' },
  effectiveRPS: '48',
  concurrency: '5.7',
  medianOkLatencyByEvent: Map(5) {
    'opened' => '0.003',
    'first-response' => '0.003',
    'requested-run' => '0.109',
    'running' => '0.112',
    'closed' => '0.115'
  }
}
```