### PR TITLE
Put cache in front of compiler

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -26,6 +26,7 @@ jobs:
           - koka-playground-compile-and-run-service
           - koka-playground-proxy
           - koka-playground-prometheus
+          - koka-playground-exe-cache
 
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG RUN_COMPILER_IMAGE=ghcr.io/dangooding/koka-zero:$RUN_COMPILER_IMAGE_SHA
 ARG NODE_BUILD_IMAGE=node:22-alpine3.22
 ARG NGINX_IMAGE=jonasal/nginx-certbot:6.0.1-nginx1.29.1-alpine
 ARG PROMETHEUS_IMAGE=prom/prometheus:v3.4.2
+ARG REDIS_IMAGE=redis:8.2.1-alpine3.22
 
 FROM $JAVA_BUILD_IMAGE AS package
 WORKDIR /build
@@ -88,3 +89,9 @@ COPY --from=frontend-build /build/dist /data/www
 FROM $PROMETHEUS_IMAGE AS koka-playground-prometheus
 
 COPY metrics/prometheus.yml /etc/prometheus/
+
+FROM $REDIS_IMAGE as koka-playground-exe-cache
+
+COPY exe-cache/redis.conf /etc/redis/
+
+CMD [ "redis-server", "/etc/redis/redis.conf" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 
 ARG JAVA_BUILD_IMAGE=maven:3.9.11-eclipse-temurin-21-alpine
 ARG RUN_IMAGE=alpine:3.22
-ARG RUN_COMPILER_IMAGE=ghcr.io/dangooding/koka-zero:main
+ARG RUN_COMPILER_IMAGE_SHA=sha256-5567093600f25501d827f0da68841626f1276fb384f754903259be5880b3f4ee
+ARG RUN_COMPILER_IMAGE=ghcr.io/dangooding/koka-zero:$RUN_COMPILER_IMAGE_SHA
 ARG NODE_BUILD_IMAGE=node:22-alpine3.22
 ARG NGINX_IMAGE=jonasal/nginx-certbot:6.0.1-nginx1.29.1-alpine
 ARG PROMETHEUS_IMAGE=prom/prometheus:v3.4.2
@@ -30,6 +31,10 @@ FROM $RUN_COMPILER_IMAGE AS run-koka-compiler
 
 FROM run-koka-compiler AS koka-playground-compile-service
 WORKDIR /app
+
+# Use the value from the same ARG at the top of the file to set the `compiler.version-hash` property
+ARG RUN_COMPILER_IMAGE_SHA
+ENV COMPILER_VERSION_HASH=${RUN_COMPILER_IMAGE_SHA}
 
 RUN apk add openjdk21-jre-headless
 RUN apk add jq

--- a/app/compile-service-app/pom.xml
+++ b/app/compile-service-app/pom.xml
@@ -24,6 +24,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <version>3.5.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>6.1.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/app/compile-service-app/src/main/java/uk/danielgooding/kokaplayground/compile/CompileServiceConfig.java
+++ b/app/compile-service-app/src/main/java/uk/danielgooding/kokaplayground/compile/CompileServiceConfig.java
@@ -1,10 +1,20 @@
 package uk.danielgooding.kokaplayground.compile;
 
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 @Configuration
 @EnableAspectJAutoProxy
@@ -13,5 +23,32 @@ public class CompileServiceConfig {
     @Bean
     TimedAspect timedAspect(MeterRegistry registry) {
         return new TimedAspect(registry);
+    }
+
+    @Bean
+    public JedisConnectionFactory redisConnectionFactory(
+            @Value("${compile.exe-cache.hostname}") String exeCacheHostname,
+            @Value("${compile.exe-cache.port}") int exeCachePort) {
+
+        // a 'standalone' redis instance (not clustered)
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(exeCacheHostname, exeCachePort);
+        return new JedisConnectionFactory(config);
+    }
+
+    @Bean
+    RedisTemplate<ExeCacheKey, byte[]> exeCacheRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<ExeCacheKey, byte[]> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(connectionFactory);
+
+        // it's important that json fields are serialised in a stable order within keys
+        Jackson2ObjectMapperBuilder objectMapperBuilder = new Jackson2ObjectMapperBuilder();
+        objectMapperBuilder.featuresToEnable(MapperFeature.SORT_CREATOR_PROPERTIES_BY_DECLARATION_ORDER);
+        ObjectMapper objectMapper = objectMapperBuilder.build();
+
+        template.setKeySerializer(new Jackson2JsonRedisSerializer<>(objectMapper, ExeCacheKey.class));
+        template.setValueSerializer(RedisSerializer.byteArray());
+
+        return template;
     }
 }

--- a/app/compile-service-app/src/main/java/uk/danielgooding/kokaplayground/compile/CompileServiceConfig.java
+++ b/app/compile-service-app/src/main/java/uk/danielgooding/kokaplayground/compile/CompileServiceConfig.java
@@ -35,7 +35,7 @@ public class CompileServiceConfig {
         return new JedisConnectionFactory(config);
     }
 
-    @Bean
+    @Bean("exeCacheRedisTemplate")
     RedisTemplate<ExeCacheKey, byte[]> exeCacheRedisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<ExeCacheKey, byte[]> template = new RedisTemplate<>();
 

--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/exe/ExeStore.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/exe/ExeStore.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 
 public interface ExeStore {
 
-    ExeHandle putExe(Path src) throws IOException;
+    ExeHandle putExe(byte[] exe) throws IOException;
 
     OrError<Path> getExe(ExeHandle handle, Workdir workdir) throws IOException;
 

--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/exe/LocalExeStore.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/exe/LocalExeStore.java
@@ -8,8 +8,9 @@ import uk.danielgooding.kokaplayground.common.OrError;
 import uk.danielgooding.kokaplayground.common.Workdir;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
 
 @Service
 @Lazy
@@ -28,9 +29,18 @@ public class LocalExeStore implements ExeStore {
     }
 
     @Override
-    public ExeHandle putExe(Path src) throws IOException {
+    public ExeHandle putExe(byte[] exe) throws IOException {
         ExeHandle handle = freshHandle();
-        Files.copy(src, Path.of(handle.getPath()));
+        Path path = Path.of(handle.getPath());
+        Files.write(path, exe,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+        Files.setPosixFilePermissions(path,
+                EnumSet.of(
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_EXECUTE));
+
         return handle;
     }
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -15,6 +15,12 @@ services:
     environment:
       <<: *common-env-vars
 
+  exe-cache:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: koka-playground-exe-cache
+
   runner-service:
     build:
       context: .

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -7,6 +7,9 @@ services:
     environment:
       <<: *common-env-vars
 
+  exe-cache:
+    image: ghcr.io/dangooding/koka-playground-exe-cache:main
+
   runner-service:
     image: ghcr.io/dangooding/koka-playground-runner-service:main
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,10 +23,24 @@ services:
       <<: *logging-env-vars
       # binds property local-exe-store.directory
       LOCALEXESTORE_DIRECTORY: "/etc/exe-store"
+      COMPILE_EXE_CACHE_HOSTNAME: "exe-cache"
+      COMPILE_EXE_CACHE_PORT: "6379"
     networks:
       common:
       monitoring:
     healthcheck: *healthcheck
+
+  exe-cache:
+    image:
+      redis:8.2.1-alpine3.22
+    networks:
+      common:
+    # TODO: add volume at /data
+    # TODO: add config file
+    healthcheck:
+      test: [ "CMD", "redis-cli", "PING" ]
+      timeout: 5s
+      interval: 30s
 
   runner-service:
     # bwrap creates zombies, so need an init process to reap them

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,9 +8,9 @@ x-health-check: &healthcheck
   interval: 30s
 
 x-logging-env-vars: &logging-env-vars
-  DEBUG: "false"
-  ORG_SPRINGFRAMEWORK_WEB_FILTER_COMMONSREQUESTLOGGINGFILTER: "WARN"
-  LOGGING_LEVEL_ROOT: "warn"
+  DEBUG: "true"
+  ORG_SPRINGFRAMEWORK_WEB_FILTER_COMMONSREQUESTLOGGINGFILTER: "DEBUG"
+  LOGGING_LEVEL_ROOT: "debug"
   MANAGEMENT_OBSERVATIONS_ANNOTATIONS_ENABLED: "true"
   SERVER_TOMCAT_MBEANREGISTRY_ENABLED: "true"
   MANAGEMENT_METRICS_DISTRIBUTION_PERCENTILES_HTTP_SERVER_REQUESTS: "0.9, 0.99"
@@ -31,12 +31,10 @@ services:
     healthcheck: *healthcheck
 
   exe-cache:
-    image:
-      redis:8.2.1-alpine3.22
     networks:
       common:
-    # TODO: add volume at /data
-    # TODO: add config file
+    # intentionally don't mount a persistent /data volume
+    # since we only run redis as a cache.
     healthcheck:
       test: [ "CMD", "redis-cli", "PING" ]
       timeout: 5s

--- a/exe-cache/redis.conf
+++ b/exe-cache/redis.conf
@@ -1,0 +1,10 @@
+
+## act as a bounded cache
+maxmemory 200mb
+maxmemory-policy allkeys-lru
+
+# don't persist to append-only-file
+appendonly no
+
+# don't snapshot
+save ""

--- a/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunTest.java
+++ b/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -17,6 +18,7 @@ import uk.danielgooding.kokaplayground.common.exe.ExeStore;
 import uk.danielgooding.kokaplayground.compile.CompileController;
 import uk.danielgooding.kokaplayground.compile.CompileService;
 import uk.danielgooding.kokaplayground.compile.CompilerTool;
+import uk.danielgooding.kokaplayground.compile.ExeCacheKey;
 import uk.danielgooding.kokaplayground.compileandrun.CompileServiceAPIClient;
 import uk.danielgooding.kokaplayground.run.RunnerService;
 import uk.danielgooding.kokaplayground.run.SandboxedExeRunner;
@@ -32,7 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
         "runner-service-hostname=UNUSED",
         "runner.max-buffered-stdin-items=10",
-        "runner.max-stderr-bytes=100"})
+        "runner.max-stderr-bytes=100",
+        "compiler.version-hash=ABCD"})
 public class CompileAndRunTest {
     // mocked services:
     @MockitoBean
@@ -58,6 +61,10 @@ public class CompileAndRunTest {
     // unused - mocked to avoid creating a real instance:
     @MockitoBean
     CompileServiceAPIClient compileServiceAPIClientMock;
+
+    // unused - mocked to avoid creating a real instance:
+    @MockitoBean("exeCacheRedisTemplate")
+    RedisTemplate<ExeCacheKey, byte[]> exeCacheKeyRedisTemplate;
 
     // test subjects:
     @Autowired

--- a/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunWebSocketTest.java
+++ b/integration/src/test/java/uk/danielgooding/kokaplayground/CompileAndRunWebSocketTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -19,6 +20,7 @@ import uk.danielgooding.kokaplayground.common.websocket.SessionId;
 import uk.danielgooding.kokaplayground.common.websocket.StatelessTypedWebSocketHandler;
 import uk.danielgooding.kokaplayground.common.websocket.TypedWebSocketSession;
 import uk.danielgooding.kokaplayground.common.websocket.TypedWebSocketSessionAndState;
+import uk.danielgooding.kokaplayground.compile.ExeCacheKey;
 import uk.danielgooding.kokaplayground.compileandrun.*;
 import uk.danielgooding.kokaplayground.protocol.CompileAndRunStream;
 import uk.danielgooding.kokaplayground.protocol.RunStream;
@@ -41,6 +43,7 @@ import static org.junit.Assert.assertThrows;
         "local-exe-store.directory=UNUSED",
         "compiler.exe-path=UNUSED",
         "compiler.koka-zero-config-path=UNUSED",
+        "compiler.version-hash=UNUSED",
         "runner.bubblewrap-path=UNUSED",
         "runner-service-hostname=UNUSED",
         "runner.max-buffered-stdin-items=10",
@@ -59,6 +62,10 @@ public class CompileAndRunWebSocketTest {
 
     @MockitoBean
     ExeStore exeStoreMock;
+
+    // unused - mocked to avoid creating a real instance:
+    @MockitoBean("exeCacheRedisTemplate")
+    RedisTemplate<ExeCacheKey, byte[]> exeCacheKeyRedisTemplate;
 
     // test subjects:
     // session -> TestCompileAndRunClientWebSocketHandler

--- a/service/compile-service/pom.xml
+++ b/service/compile-service/pom.xml
@@ -14,4 +14,12 @@
 
     <packaging>jar</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <version>3.5.2</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/CompileService.java
+++ b/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/CompileService.java
@@ -1,51 +1,79 @@
 package uk.danielgooding.kokaplayground.compile;
 
-import jakarta.annotation.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 import uk.danielgooding.kokaplayground.common.*;
 import uk.danielgooding.kokaplayground.common.exe.ExeHandle;
 import uk.danielgooding.kokaplayground.common.exe.ExeStore;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Service
 public class CompileService {
+    @Autowired
+    private ExeCache exeCache;
+
     @Autowired
     private CompilerTool compilerTool;
 
     @Autowired
     private ExeStore exeStore;
 
+    private static final Logger logger = LoggerFactory.getLogger(CompileService.class);
+
     public CompletableFuture<OrError<Void>> typecheck(KokaSourceCode sourceCode) {
         return compilerTool.typecheck(sourceCode);
     }
 
     public CompletableFuture<OrError<ExeHandle>> compile(KokaSourceCode sourceCode, boolean optimise) {
-        CompletableFuture<OrError<Path>> result = compilerTool.compile(sourceCode, optimise);
 
-        return result.thenCompose(
-                (maybeLocalExe) -> {
-                    switch (maybeLocalExe) {
-                        case Failed<?> error -> {
-                            return CompletableFuture.completedFuture(error.castValue());
-                        }
-                        case Ok<Path> localExe -> {
-                            try {
-                                ExeHandle handle = exeStore.putExe(localExe.getValue());
-                                return CompletableFuture.completedFuture(OrError.ok(handle));
-                            } catch (IOException e) {
-                                return CompletableFuture.failedFuture(e);
+        Optional<byte[]> compiledExe = exeCache.getCompiledExe(sourceCode, optimise);
+
+        if (compiledExe.isEmpty()) {
+            logger.info("exe not found in cache, compiling");
+
+            CompletableFuture<OrError<Path>> result = compilerTool.compile(sourceCode, optimise);
+
+            return result.thenCompose(
+                    (maybeLocalExe) -> {
+                        switch (maybeLocalExe) {
+                            case Failed<?> error -> {
+                                // we don't cache errors
+                                return CompletableFuture.completedFuture(error.castValue());
                             }
+                            case Ok<Path> localExe -> {
+                                try {
+                                    byte[] exe = Files.readAllBytes(localExe.getValue());
+                                    exeCache.putCompiledExe(sourceCode, optimise, exe);
+
+                                    return uploadAndReturnExe(exe);
+                                } catch (IOException e) {
+                                    return CompletableFuture.failedFuture(e);
+                                }
+                            }
+
                         }
-
                     }
-                }
-        );
+            );
 
+        } else {
+            logger.info("exe found in cache, skipping compiler");
+            return uploadAndReturnExe(compiledExe.get());
+        }
+    }
+
+    public CompletableFuture<OrError<ExeHandle>> uploadAndReturnExe(byte[] exe) {
+        try {
+            ExeHandle handle = exeStore.putExe(exe);
+            return CompletableFuture.completedFuture(OrError.ok(handle));
+        } catch (IOException e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 }

--- a/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCache.java
+++ b/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCache.java
@@ -1,6 +1,7 @@
 package uk.danielgooding.kokaplayground.compile;
 
 import jakarta.annotation.Resource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import uk.danielgooding.kokaplayground.common.KokaSourceCode;
@@ -13,13 +14,16 @@ public class ExeCache {
     @Resource(name = "exeCacheRedisTemplate")
     private ValueOperations<ExeCacheKey, byte[]> redisValueOperations;
 
+    @Value("${compiler.version-hash}")
+    String compilerVersionHash;
+
     public Optional<byte[]> getCompiledExe(KokaSourceCode code, boolean optimise) {
-        ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise);
+        ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise, compilerVersionHash);
         return Optional.ofNullable(redisValueOperations.get(key));
     }
 
     public void putCompiledExe(KokaSourceCode code, boolean optimise, byte[] exe) {
-        ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise);
+        ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise, compilerVersionHash);
         redisValueOperations.set(key, exe);
     }
 

--- a/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCache.java
+++ b/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCache.java
@@ -1,7 +1,11 @@
 package uk.danielgooding.kokaplayground.compile;
 
-import jakarta.annotation.Resource;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import uk.danielgooding.kokaplayground.common.KokaSourceCode;
@@ -10,21 +14,45 @@ import java.util.Optional;
 
 @Service
 public class ExeCache {
+    private final ValueOperations<ExeCacheKey, byte[]> redisValueOperations;
+    private final String compilerVersionHash;
 
-    @Resource(name = "exeCacheRedisTemplate")
-    private ValueOperations<ExeCacheKey, byte[]> redisValueOperations;
+    private final Counter hitCounter;
+    private final Counter missCounter;
 
-    @Value("${compiler.version-hash}")
-    String compilerVersionHash;
+    public ExeCache(
+            @Autowired @Qualifier("exeCacheRedisTemplate") RedisTemplate<ExeCacheKey, byte[]> redisTemplate,
+            @Value("${compiler.version-hash}") String compilerVersionHash,
+            @Autowired MeterRegistry meterRegistry
+    ) {
+        this.redisValueOperations = redisTemplate.opsForValue();
+        this.compilerVersionHash = compilerVersionHash;
+
+
+        hitCounter = makeOutcomeCounter(meterRegistry, true);
+        missCounter = makeOutcomeCounter(meterRegistry, false);
+    }
 
     public Optional<byte[]> getCompiledExe(KokaSourceCode code, boolean optimise) {
         ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise, compilerVersionHash);
-        return Optional.ofNullable(redisValueOperations.get(key));
+
+        Optional<byte[]> result = Optional.ofNullable(redisValueOperations.get(key));
+
+        (result.isEmpty() ? missCounter : hitCounter).increment();
+
+        return result;
     }
 
     public void putCompiledExe(KokaSourceCode code, boolean optimise, byte[] exe) {
         ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise, compilerVersionHash);
         redisValueOperations.set(key, exe);
+    }
+
+    private Counter makeOutcomeCounter(MeterRegistry meterRegistry, boolean hit) {
+        return Counter.builder("cache_result")
+                .tag("cache", "exe-cache")
+                .tag("outcome", hit ? "hit" : "miss")
+                .register(meterRegistry);
     }
 
 }

--- a/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCache.java
+++ b/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCache.java
@@ -1,0 +1,26 @@
+package uk.danielgooding.kokaplayground.compile;
+
+import jakarta.annotation.Resource;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import uk.danielgooding.kokaplayground.common.KokaSourceCode;
+
+import java.util.Optional;
+
+@Service
+public class ExeCache {
+
+    @Resource(name = "exeCacheRedisTemplate")
+    private ValueOperations<ExeCacheKey, byte[]> redisValueOperations;
+
+    public Optional<byte[]> getCompiledExe(KokaSourceCode code, boolean optimise) {
+        ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise);
+        return Optional.ofNullable(redisValueOperations.get(key));
+    }
+
+    public void putCompiledExe(KokaSourceCode code, boolean optimise, byte[] exe) {
+        ExeCacheKey key = ExeCacheKey.forSourceCode(code, optimise);
+        redisValueOperations.set(key, exe);
+    }
+
+}

--- a/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCacheKey.java
+++ b/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCacheKey.java
@@ -11,17 +11,26 @@ import java.security.NoSuchAlgorithmException;
 public class ExeCacheKey {
     private static final String digestAlgorithm = "SHA-1";
 
+    /// Hash of the compiler itself - used to ensure we invalidate all entries
+    /// when a new compiler version is released.
+    private final String compilerHash;
+
+    /// Hash of the source-code - keys should not be long.
     private final byte[] sourceCodeHash;
+
+    /// Was this compiled with optimisations enabled
     private final boolean optimised;
 
     public ExeCacheKey(
             @JsonProperty("sourceCodeHash") byte[] sourceCodeHash,
-            @JsonProperty("optimised") boolean optimised) {
+            @JsonProperty("optimised") boolean optimised,
+            @JsonProperty("compilerHash") String compilerHash) {
         this.sourceCodeHash = sourceCodeHash;
         this.optimised = optimised;
+        this.compilerHash = compilerHash;
     }
 
-    public static ExeCacheKey forSourceCode(KokaSourceCode code, boolean optimised) {
+    public static ExeCacheKey forSourceCode(KokaSourceCode code, boolean optimised, String compilerHash) {
         MessageDigest md;
         try {
             md = MessageDigest.getInstance(digestAlgorithm);
@@ -32,7 +41,7 @@ public class ExeCacheKey {
         }
         md.update(code.getCode().getBytes(StandardCharsets.UTF_8));
         byte[] hash = md.digest();
-        return new ExeCacheKey(hash, optimised);
+        return new ExeCacheKey(hash, optimised, compilerHash);
     }
 
     @JsonGetter("sourceCodeHash")
@@ -43,5 +52,10 @@ public class ExeCacheKey {
     @JsonGetter("optimised")
     public boolean isOptimised() {
         return optimised;
+    }
+
+    @JsonGetter("compilerHash")
+    public String getCompilerHash() {
+        return compilerHash;
     }
 }

--- a/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCacheKey.java
+++ b/service/compile-service/src/main/java/uk/danielgooding/kokaplayground/compile/ExeCacheKey.java
@@ -1,0 +1,47 @@
+package uk.danielgooding.kokaplayground.compile;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.danielgooding.kokaplayground.common.KokaSourceCode;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class ExeCacheKey {
+    private static final String digestAlgorithm = "SHA-1";
+
+    private final byte[] sourceCodeHash;
+    private final boolean optimised;
+
+    public ExeCacheKey(
+            @JsonProperty("sourceCodeHash") byte[] sourceCodeHash,
+            @JsonProperty("optimised") boolean optimised) {
+        this.sourceCodeHash = sourceCodeHash;
+        this.optimised = optimised;
+    }
+
+    public static ExeCacheKey forSourceCode(KokaSourceCode code, boolean optimised) {
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance(digestAlgorithm);
+        } catch (NoSuchAlgorithmException e) {
+            // Ideally we should be able to assert this will work once at startup.
+            // Regardless, we cannot continue if it fails.
+            throw new RuntimeException("missing algorithm provider", e);
+        }
+        md.update(code.getCode().getBytes(StandardCharsets.UTF_8));
+        byte[] hash = md.digest();
+        return new ExeCacheKey(hash, optimised);
+    }
+
+    @JsonGetter("sourceCodeHash")
+    public byte[] getSourceCodeHash() {
+        return sourceCodeHash;
+    }
+
+    @JsonGetter("optimised")
+    public boolean isOptimised() {
+        return optimised;
+    }
+}


### PR DESCRIPTION
Running the koka compiler takes about 100ms, presumably mostly compute rather than I/O. This adds noticeable delay to requests, and limits our throughput.

Put a redis cache in front of the compiler: keys are `(SHA(source code), compiler_options, compiler_version)` and values are the executables. Hits have a latency of ~10ms.

We can't expect hits to be that common in general, however: 
- the website has some example programs, so most users will just be running those.
- users will likely run a program multiple times after they've written it.