### PR TITLE
Recover client IP when request is from cloudflare

### DIFF
--- a/client/cloudflare-ips.conf
+++ b/client/cloudflare-ips.conf
@@ -1,0 +1,24 @@
+# Cloudflare IP ranges - https://www.cloudflare.com/en-gb/ips/
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 131.0.72.0/22;
+
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;

--- a/client/proxy-common.conf
+++ b/client/proxy-common.conf
@@ -1,4 +1,4 @@
 proxy_set_header Host $host;
-proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
+include /etc/nginx/user_conf.d/cloudflare-ips.conf;
+real_ip_header CF-Connecting-IP;


### PR DESCRIPTION
Get the client's true IP when they are proxied through cloudflare. Currently just use this for display in logs.