### PR TITLE
Execution time limits

### DIFF
--- a/app/runner-service-app/src/main/java/uk/danielgooding/kokaplayground/run/RunnerServiceConfig.java
+++ b/app/runner-service-app/src/main/java/uk/danielgooding/kokaplayground/run/RunnerServiceConfig.java
@@ -40,4 +40,14 @@ public class RunnerServiceConfig {
                 "runner.stdout-reader-executor",
                 environment);
     }
+
+    @Bean(name = "run-time-limiter")
+    public Executor runTimeLimiterExecutor(MeterRegistry meterRegistry, Environment environment) {
+        return MonitoredThreadPoolExecutor.create(
+                meterRegistry,
+                "runTimeLimiter",
+                "run-time-limiter-",
+                "runner.run-time-limiter-executor",
+                environment);
+    }
 }

--- a/app/runner-service-app/src/main/resources/application.properties
+++ b/app/runner-service-app/src/main/resources/application.properties
@@ -5,3 +5,5 @@ runner.max-buffered-stdin-items=1000
 runner.max-stderr-bytes=1000
 runner.stdout-reader-executor.pool.core-size=10
 runner.stdin-writer-executor.pool.core-size=10
+runner.run-time-limiter.pool.core-size=10
+runner.real-time-limit-seconds=60

--- a/common/src/main/java/uk/danielgooding/kokaplayground/common/OrInterrupted.java
+++ b/common/src/main/java/uk/danielgooding/kokaplayground/common/OrInterrupted.java
@@ -1,0 +1,96 @@
+package uk.danielgooding.kokaplayground.common;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public abstract sealed class OrInterrupted<T> {
+    public abstract <U> OrInterrupted<U> thenApply(Function<T, U> fn);
+
+    public static <T> Ok<T> ok(T t) {
+        return new Ok<>(t);
+    }
+
+    public static <T> Interrupted<T> interrupted() {
+        return new Interrupted<>();
+    }
+
+    public abstract <U> OrInterrupted<U> map(Function<T, U> f);
+
+    @Override
+    public abstract String toString();
+
+    @Override
+    public abstract boolean equals(Object obj);
+
+    @Override
+    public abstract int hashCode();
+
+    public static final class Ok<T> extends OrInterrupted<T> {
+        private final T result;
+
+        public Ok(T result) {
+            this.result = result;
+        }
+
+        public T getResult() {
+            return result;
+        }
+
+        @Override
+        public <U> OrInterrupted<U> thenApply(Function<T, U> fn) {
+            return OrInterrupted.ok(fn.apply(result));
+        }
+
+        @Override
+        public <U> OrInterrupted<U> map(Function<T, U> f) {
+            return new Ok<>(f.apply(result));
+        }
+
+        @Override
+        public String toString() {
+            return "Ok{" +
+                    "result=" + result +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            Ok<?> ok = (Ok<?>) o;
+            return Objects.equals(result, ok.result);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(result);
+        }
+    }
+
+    public static final class Interrupted<T> extends OrInterrupted<T> {
+        @Override
+        public <U> OrInterrupted<U> thenApply(Function<T, U> fn) {
+            return OrInterrupted.interrupted();
+        }
+
+        @Override
+        public <U> OrInterrupted<U> map(Function<T, U> f) {
+            return OrInterrupted.interrupted();
+        }
+
+        @Override
+        public String toString() {
+            return "Interrupted";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o != null && getClass() == o.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(null);
+        }
+    }
+
+}

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/ExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/ExeRunner.java
@@ -9,6 +9,7 @@ import uk.danielgooding.kokaplayground.common.OrError;
 import uk.danielgooding.kokaplayground.common.Subprocess;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -24,6 +25,10 @@ public class ExeRunner implements IExeRunner {
     @Autowired
     @Qualifier("stdout-reader")
     Executor stdoutReaderExecutor;
+
+    @Autowired
+    @Qualifier("run-time-limiter")
+    Executor runTimeLimiterExecutor;
 
     private <T> OrError<T> resultForOutput(Subprocess.Output output, Supplier<T> getOkResult) {
         if (output.isExitSuccess()) {
@@ -44,10 +49,12 @@ public class ExeRunner implements IExeRunner {
             List<String> args,
             BlockingQueue<String> stdinBuffer,
             Callback<Void> onStart,
-            Callback<String> onStdout) {
+            Callback<String> onStdout,
+            Duration realTimeLimit) {
 
         return Subprocess.runStreamingStdinAndStdout(
-                        exe, args, stdinBuffer, onStart, onStdout, stdoutReaderExecutor, stdinWriterExecutor)
+                        exe, args, stdinBuffer, onStart, onStdout, realTimeLimit,
+                        runTimeLimiterExecutor, stdoutReaderExecutor, stdinWriterExecutor)
                 .thenApply(output -> resultForOutput(output, () -> null));
     }
 }

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/ExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/ExeRunner.java
@@ -3,10 +3,7 @@ package uk.danielgooding.kokaplayground.run;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import uk.danielgooding.kokaplayground.common.Callback;
-import uk.danielgooding.kokaplayground.common.CancellableFuture;
-import uk.danielgooding.kokaplayground.common.OrError;
-import uk.danielgooding.kokaplayground.common.Subprocess;
+import uk.danielgooding.kokaplayground.common.*;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -44,7 +41,7 @@ public class ExeRunner implements IExeRunner {
         return Subprocess.runThenGetStdout(exe, args, stdin).thenApply(output -> resultForOutput(output, output::stdout));
     }
 
-    public CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(
+    public CancellableFuture<OrInterrupted<OrError<Void>>> runStreamingStdinAndStdout(
             Path exe,
             List<String> args,
             BlockingQueue<String> stdinBuffer,
@@ -55,6 +52,6 @@ public class ExeRunner implements IExeRunner {
         return Subprocess.runStreamingStdinAndStdout(
                         exe, args, stdinBuffer, onStart, onStdout, realTimeLimit,
                         runTimeLimiterExecutor, stdoutReaderExecutor, stdinWriterExecutor)
-                .thenApply(output -> resultForOutput(output, () -> null));
+                .thenApply(result -> result.map(output -> resultForOutput(output, () -> null)));
     }
 }

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/IExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/IExeRunner.java
@@ -3,6 +3,7 @@ package uk.danielgooding.kokaplayground.run;
 import uk.danielgooding.kokaplayground.common.Callback;
 import uk.danielgooding.kokaplayground.common.CancellableFuture;
 import uk.danielgooding.kokaplayground.common.OrError;
+import uk.danielgooding.kokaplayground.common.OrInterrupted;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -15,7 +16,7 @@ public interface IExeRunner {
 
     CompletableFuture<OrError<String>> runThenGetStdout(Path exe, List<String> args, String stdin);
 
-    CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(
+    CancellableFuture<OrInterrupted<OrError<Void>>> runStreamingStdinAndStdout(
             Path exe,
             List<String> args,
             BlockingQueue<String> stdinBuffer,

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/IExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/IExeRunner.java
@@ -5,6 +5,7 @@ import uk.danielgooding.kokaplayground.common.CancellableFuture;
 import uk.danielgooding.kokaplayground.common.OrError;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -19,5 +20,6 @@ public interface IExeRunner {
             List<String> args,
             BlockingQueue<String> stdinBuffer,
             Callback<Void> onStart,
-            Callback<String> onStdout);
+            Callback<String> onStdout,
+            Duration realTimeLimit);
 }

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/RunnerService.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/RunnerService.java
@@ -34,30 +34,6 @@ public class RunnerService {
         this.workdir = workdir;
     }
 
-    public CompletableFuture<OrError<String>> runWithoutStdin(ExeHandle handle) {
-        try {
-            Path exe;
-            switch (exeStore.getExe(handle, workdir)) {
-                case Failed<?> failed -> {
-                    return CompletableFuture.completedFuture(failed.castValue());
-                }
-                case Ok<Path> okExe -> {
-                    exe = okExe.getValue();
-                }
-            }
-
-            CompletableFuture<OrError<String>> stdout =
-                    exeRunner.runThenGetStdout(exe, List.of(), "");
-
-            exeStore.deleteExe(handle);
-
-            return stdout;
-
-        } catch (IOException e) {
-            return CompletableFuture.failedFuture(e);
-        }
-    }
-
     public CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(
             ExeHandle handle, BlockingQueue<String> stdinBuffer, Callback<Void> onStart, Callback<String> onStdout) {
         try {

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/RunnerService.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/RunnerService.java
@@ -42,20 +42,20 @@ public class RunnerService {
         this.realTimeLimit = Duration.ofSeconds(realTimeLimitSeconds);
     }
 
-    public CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(
+    public CancellableFuture<OrInterrupted<OrError<Void>>> runStreamingStdinAndStdout(
             ExeHandle handle, BlockingQueue<String> stdinBuffer, Callback<Void> onStart, Callback<String> onStdout) {
         try {
             Path exe;
             switch (exeStore.getExe(handle, workdir)) {
                 case Failed<?> failed -> {
-                    return CancellableFuture.completedFuture(failed.castValue());
+                    return CancellableFuture.completedFuture(OrInterrupted.ok(failed.castValue()));
                 }
                 case Ok<Path> okExe -> {
                     exe = okExe.getValue();
                 }
             }
 
-            CancellableFuture<OrError<Void>> runOutcome =
+            CancellableFuture<OrInterrupted<OrError<Void>>> runOutcome =
                     exeRunner.runStreamingStdinAndStdout(exe, List.of(), stdinBuffer, onStart, onStdout, realTimeLimit);
 
             return runOutcome.whenComplete((ignored, exn) -> {

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/RunnerSessionState.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/RunnerSessionState.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 public class RunnerSessionState implements ISessionState<RunnerSessionState.StateTag> {
-    private @Nullable CancellableFuture<OrError<Void>> running;
+    private @Nullable CancellableFuture<?> running;
     private final BlockingQueue<String> stdinBuffer;
     private final Timer.Sample sessionSample;
     private StateTag state = StateTag.AWAITING_RUN;
@@ -35,7 +35,7 @@ public class RunnerSessionState implements ISessionState<RunnerSessionState.Stat
         return running != null && running.isDone();
     }
 
-    public void setRunning(CancellableFuture<OrError<Void>> running) {
+    public void setRunning(CancellableFuture<?> running) {
         this.running = running;
     }
 

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/SandboxedExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/SandboxedExeRunner.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.danielgooding.kokaplayground.common.Callback;
 import uk.danielgooding.kokaplayground.common.CancellableFuture;
 import uk.danielgooding.kokaplayground.common.OrError;
+import uk.danielgooding.kokaplayground.common.OrInterrupted;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -53,7 +54,7 @@ public class SandboxedExeRunner implements IExeRunner {
     }
 
     @Override
-    public CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(
+    public CancellableFuture<OrInterrupted<OrError<Void>>> runStreamingStdinAndStdout(
             Path exe,
             List<String> exeArgs,
             BlockingQueue<String> stdinBuffer,

--- a/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/SandboxedExeRunner.java
+++ b/service/runner-service/src/main/java/uk/danielgooding/kokaplayground/run/SandboxedExeRunner.java
@@ -8,6 +8,7 @@ import uk.danielgooding.kokaplayground.common.CancellableFuture;
 import uk.danielgooding.kokaplayground.common.OrError;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -52,8 +53,15 @@ public class SandboxedExeRunner implements IExeRunner {
     }
 
     @Override
-    public CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(Path exe, List<String> exeArgs, BlockingQueue<String> stdinBuffer, Callback<Void> onStart, Callback<String> onStdout) {
+    public CancellableFuture<OrError<Void>> runStreamingStdinAndStdout(
+            Path exe,
+            List<String> exeArgs,
+            BlockingQueue<String> stdinBuffer,
+            Callback<Void> onStart,
+            Callback<String> onStdout,
+            Duration realTimeLimit) {
         List<String> args = addBubblewrapArgs(exe, exeArgs);
-        return exeRunner.runStreamingStdinAndStdout(bubblewrapPath, args, stdinBuffer, onStart, onStdout);
+        return exeRunner.runStreamingStdinAndStdout(
+                bubblewrapPath, args, stdinBuffer, onStart, onStdout, realTimeLimit);
     }
 }


### PR DESCRIPTION
Add a timeout on running user code. This currently measures wall-clock time, and is pretty generous to allow waiting for users to type input.

When terminated, we send an `Interrupted` message to the user.